### PR TITLE
Backporting from YGGFetch

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,6 +125,12 @@ async function resolveCallenge(params, browser, res, startTimestamp) {
   const userAgent = await page.evaluate(() => navigator.userAgent);
   log.debug("User-Agent: " + userAgent);
   const reqUrl = params["url"];
+  const reqCookies = params["cookies"];
+
+  if (reqCookies) {
+    log.debug('Applying cookies');
+    await page.setCookie(...cookies);
+  }
 
   log.debug("Navegating to... " + reqUrl);
   await page.goto(reqUrl, {waitUntil: 'networkidle0'});

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ function processRequest(params, req, res, startTimestamp) {
     } catch (error) {
       errorResponse(error.message, res, startTimestamp);
     } finally {
-      //await browser.close();
+      await browser.close();
     }
   }).catch(error => {
     errorResponse(error.message, res, startTimestamp);

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const log = require('console-log-level')(
 {
   level: process.env.LOG_LEVEL || 'info',
   prefix: function (level) {
-    return new Date().toISOString() + " " + level.toUpperCase();
+    return reqCounter.toString() + " " + new Date().toISOString() + " " + level.toUpperCase();
   }
 });
 const puppeteer = require('puppeteer-extra');
@@ -18,10 +18,13 @@ const logHtml = process.env.LOG_HTML || false;
 // in each request. we set the user-agent in the browser args instead
 puppeteer.use(StealthPlugin());
 
+// Help logging
+var reqCounter = 0;
+
 http.createServer(function(req, res) {
+  reqCounter++;
   const startTimestamp = Date.now();
   log.info('Incoming request: ' + req.method + " " + req.url);
-
   var body = [];
   req.on('data', function(chunk) {
       body.push(chunk);

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ async function resolveCallenge(params, browser, res, startTimestamp) {
 
   if (reqCookies) {
     log.debug('Applying cookies');
-    await page.setCookie(...cookies);
+    await page.setCookie(...reqCookies);
   }
 
   log.debug("Navegating to... " + reqUrl);


### PR DESCRIPTION
Hey 🖖 

I checked your code and I don't have much to say about it ! You even thought about the weird edge case I encounter while testing YGGFetch.
About the push request:
- reqCounter is very helpful when you read log and you have several requests at the same time
- I've added reqCookies, that you can pass to the app so Jackett can pass the returned cloudflare cookies and avoid as much as possible the challenge. It should respect this format: https://github.com/puppeteer/puppeteer/blob/v3.3.0/docs/api.md#pagesetcookiecookies
- I also un-commented the browser closing. I was experiencing some intensive load after 1 day when I wasn't closing the browser either.

Not in the PR:
- You can use adblocker to speedup navigation and save some bandwith (https://www.npmjs.com/package/puppeteer-extra-plugin-adblocker). Always good to have adblock on trackers from my point of view.
- Puppeteer does not work on ARM based CPU. If this project is implemented into Jackett, I would warn user to avoid github tickets.
- If there will be a lot of incoming requests, maybe you should consider having the browser opening when the script launch and not at incoming request. You would need to deal with pages. Pros: Faster since you only open a new tabs per request. Cons: At idle, you consume more RAM.
- On the README, I guess you should insist on the fact that the captcha appear based on the IP Reputation.

Feel free to ask if you have any questions 🚀 